### PR TITLE
Changing the userinfo endpoint interaction code to be standard.  

### DIFF
--- a/octoprint_oauth2/oauth_user_manager.py
+++ b/octoprint_oauth2/oauth_user_manager.py
@@ -80,13 +80,12 @@ class OAuthbasedUserManager(FilebasedUserManager):
         This method make a request to resource server.
         Then tries if specific username_key is OK and return username.
         """
-
         try:
             # GET user data from resource server
-            params = {
-                self.access_token_query_key: oauth2_session.access_token
-            }
-            response = requests.get(self.path_user_info, params=params)
+            headers = {
+                "Authorization" : "Bearer " + oauth2_session.access_token
+            } 
+            response = requests.get(self.path_user_info, headers=headers)
             data = response.json()
 
             # Try if data contains username_key from config file

--- a/octoprint_oauth2/static/js/oauth2.js
+++ b/octoprint_oauth2/static/js/oauth2.js
@@ -77,7 +77,7 @@ $(function() {
 
                     self.loginState.fromResponse(response);
                 })
-                .error(function(error) {
+                .fail(function(error) {
                     if (error && error.status === 401) {
                          self.loginState.fromResponse(false);
                     }


### PR DESCRIPTION
This code uses a sparsely supported method of setting an access_code param in the get.  This isn't standard so breaks some oauth2 (Keycloak in particular).  The standard way is to send the token as a bearer token in an authorization header.   This updates the code to follow the standard better, which should ensure wider compatibility.